### PR TITLE
Update GitHub Actions and add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test-build-and-push.yml
+++ b/.github/workflows/test-build-and-push.yml
@@ -19,14 +19,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run tests
         run: ./test/run.sh
 
       - name: Log in to the Container registry
         if: github.ref == 'refs/heads/main'
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -35,7 +35,7 @@ jobs:
       - name: Extract metadata (tags, labels) for Docker
         if: github.ref == 'refs/heads/main'
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
@@ -45,7 +45,7 @@ jobs:
 
       - name: Build and push Docker image
         if: github.ref == 'refs/heads/main'
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true


### PR DESCRIPTION
GitHub Actions in the CI workflow were outdated. This updates all actions to their latest major versions (checkout v4, login-action v3, metadata-action v5, build-push-action v6) and adds a Dependabot configuration to keep Docker base images and GitHub Actions up to date going forward. Merging will also re-enable the CI workflow that was disabled due to repository inactivity.