### PR TITLE
Migrate test suite from docker-compose v1 to v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM ghcr.io/borg-fleet/sssd
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes borgbackup openssh-server
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes borgbackup openssh-server && \
+    rm -rf /var/lib/apt/lists/*
 RUN pam-auth-update --enable mkhomedir
 RUN mkdir /run/sshd && rm /etc/ssh/ssh_host*
 

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   ldap:
     image: osixia/openldap:1.5.0

--- a/test/run.sh
+++ b/test/run.sh
@@ -5,8 +5,14 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 cd "${SCRIPT_DIR}"
 
+cleanup() {
+  echo "Cleaning up..."
+  docker compose down -v 2>/dev/null || true
+}
+trap cleanup EXIT
+
 echo "Starting test setup..."
-docker-compose up -d
+docker compose up -d
 
 
 echo "Wait for LDAP to become online..."
@@ -24,7 +30,7 @@ done
 
 echo "Waiting for SSSD to find LDAP..."
 SECONDS=0
-until docker logs test_sssd_1 2>&1 | grep -q "Marking port 389 of server 'ldap' as 'working'"
+until docker logs test-sssd-1 2>&1 | grep -q "Marking port 389 of server 'ldap' as 'working'"
 do
   if (( SECONDS > 180 ))
   then
@@ -38,7 +44,7 @@ done
 sleep 1
 
 function exec_in_borg_container() {
-  docker exec -e 'BORG_REPO=billy@borg:backup' -e 'BORG_PASSPHRASE=test-passphrase' -e 'BORG_RSH=ssh -i /ssh_keys/id_ed25519 -o "StrictHostKeyChecking no"' test_borg-client_1 "$@"
+  docker exec -e 'BORG_REPO=billy@borg:backup' -e 'BORG_PASSPHRASE=test-passphrase' -e 'BORG_RSH=ssh -i /ssh_keys/id_ed25519 -o "StrictHostKeyChecking no"' test-borg-client-1 "$@"
 }
 
 echo "Test: Init borg repo"


### PR DESCRIPTION
The `ubuntu-latest` GitHub Actions runners no longer include the standalone `docker-compose` (v1) binary, which causes all CI runs to fail with `docker-compose: command not found`.

This switches the test script to use the `docker compose` plugin (v2), updates container name references from the v1 naming convention (underscores: `test_sssd_1`) to v2 (hyphens: `test-sssd-1`), removes the obsolete `version` key from `docker-compose.yml`, and adds a cleanup trap to tear down containers on exit.

Once merged, the four pending Dependabot PRs should pass CI as well.