### PR TITLE
Fix missing ENTRYPOINT, test typo, and unused volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,5 @@ ADD entrypoint.sh /entrypoint.sh
 
 EXPOSE 22
 
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/usr/sbin/sshd","-D", "-e"]

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -91,4 +91,3 @@ services:
 
 volumes:
   sssd-pipes: {}
-  openldap-certs: {}

--- a/test/run.sh
+++ b/test/run.sh
@@ -57,4 +57,4 @@ exec_in_borg_container borg create --stats ::FIRST /root/important-files
 echo "Test: List backups"
 exec_in_borg_container borg list | grep -q FIRST
 
-echo "TESTS PASSWD"
+echo "TESTS PASSED"


### PR DESCRIPTION
The `entrypoint.sh` script (which generates SSH host keys and optionally injects SSHD config) is added to the image but never set as ENTRYPOINT, so it never runs. This adds the missing `ENTRYPOINT ["/entrypoint.sh"]` directive before the existing CMD.

Also fixes the "TESTS PASSWD" -> "TESTS PASSED" typo in `test/run.sh` and removes the unused `openldap-certs` volume from `test/docker-compose.yml`.